### PR TITLE
Version 1.1.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,6 @@
     "open_in_tab": false
   },
   "permissions": [
-    "tabs",
     "storage"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Super Refresh",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Refresh all the tabs!  Click on the extension icon or use the keyboard shortcut to reload all open tabs in the current window.",
   "icons": {
     "16": "icon-16.png",


### PR DESCRIPTION
Reduced permission scope.  Tabs permission is not required, because only the  `url`, `pendingUrl`, `title`, or `favIconUrl` properties require explicit permission.  This is a good update for users which helps protect privacy!

https://developer.chrome.com/docs/extensions/reference/tabs/